### PR TITLE
테스트에 ZIO Test 라이브러리 적용

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,23 +4,24 @@ ThisBuild / scalaVersion := "2.13.8"
 val zioVersion = "2.0.15"
 
 lazy val sharedSettings = Seq(
-    libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % zioVersion,
-      "dev.zio" %% "zio-test" % zioVersion % Test,
-      "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
-      "dev.zio" %% "zio-config" % "4.0.0-RC14",
-      "dev.zio" %% "zio-config-typesafe" % "4.0.0-RC14",
-      "dev.zio" %% "zio-config-magnolia" % "4.0.0-RC14",
-      "dev.zio" %% "zio-config-refined" % "4.0.0-RC14",
-      "dev.zio" %% "zio-http" % "3.0.0-RC2",
-      "dev.zio" %% "zio-json" % "0.6.0",
-      "com.lihaoyi" %% "ujson" % "3.0.0",
-      "com.softwaremill.sttp.client3" %% "core" % "3.8.16",
-      "com.softwaremill.sttp.client3" %% "zio-json" % "3.8.16",
-      "com.softwaremill.sttp.client3" %% "zio" % "3.8.16",
-      "com.lihaoyi" %% "os-lib" % "0.9.1",
-      "com.lihaoyi" %% "ujson" % "3.0.0"
-  )
+  libraryDependencies ++= Seq(
+    "dev.zio" %% "zio" % zioVersion,
+    "dev.zio" %% "zio-test" % zioVersion % Test,
+    "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
+    "dev.zio" %% "zio-config" % "4.0.0-RC14",
+    "dev.zio" %% "zio-config-typesafe" % "4.0.0-RC14",
+    "dev.zio" %% "zio-config-magnolia" % "4.0.0-RC14",
+    "dev.zio" %% "zio-config-refined" % "4.0.0-RC14",
+    "dev.zio" %% "zio-http" % "3.0.0-RC2",
+    "dev.zio" %% "zio-json" % "0.6.0",
+    "com.lihaoyi" %% "ujson" % "3.0.0",
+    "com.softwaremill.sttp.client3" %% "core" % "3.8.16",
+    "com.softwaremill.sttp.client3" %% "zio-json" % "3.8.16",
+    "com.softwaremill.sttp.client3" %% "zio" % "3.8.16",
+    "com.lihaoyi" %% "os-lib" % "0.9.1",
+    "com.lihaoyi" %% "ujson" % "3.0.0"
+  ),
+  testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )
 
 lazy val root = project
@@ -29,4 +30,3 @@ lazy val root = project
     name := "cheese-shop"
   )
   .settings(sharedSettings)
-

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -1,9 +1,6 @@
-// For more information on writing tests, see
-// https://scalameta.org/munit/docs/getting-started.html
-class MySuite extends munit.FunSuite {
-  test("example test that succeeds") {
-    val obtained = 42
-    val expected = 42
-    assertEquals(obtained, expected)
-  }
+import zio.test._
+
+object MySuite extends ZIOSpecDefault {
+  def spec = suite("MySuite")(
+  )
 }


### PR DESCRIPTION
Scala의 기본 테스트 라이브러리는 MUnit입니다만, ZIO 의존성을 설정하며 제거한 바 있습니다. ZIO 애플리케이션은 [`ZIO Test`](https://zio.dev/reference/test/)를 사용하기 때문에, 기존의 테스트 코드를 지우고 `ZIO Test`를 사용할 수 있도록 작성하였습니다.